### PR TITLE
Refactor entity deletion and fix AI death limbo

### DIFF
--- a/BattleNetwork/bnBuster.cpp
+++ b/BattleNetwork/bnBuster.cpp
@@ -53,7 +53,7 @@ void Buster::Update(float _elapsed) {
       setPosition(tile->getPosition().x + tile->GetWidth() / 2.f + random, tile->getPosition().y + tile->GetHeight() / 2.f - hitHeight);
     }
     progress += 0.2f;
-    animation(*this, progress);
+    animation(*this, fmin(progress, 1.0f));
     if (progress >= 1.f) {
       deleted = true;
     }

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1,4 +1,6 @@
 #include "bnEntity.h"
+#include "bnTile.h"
+#include "bnField.h"
 
 Entity::Entity(void)
   : tile(nullptr),
@@ -6,6 +8,7 @@ Entity::Entity(void)
   previous(nullptr),
   field(nullptr),
   team(Team::UNKNOWN),
+  health(0),
   deleted(false) {
 }
 
@@ -13,6 +16,10 @@ Entity::~Entity(void) {
 }
 
 void Entity::Update(float _elapsed) {
+  if (IsDeleted()) {
+    tile->RemoveEntity(this);
+    field->RemoveEntity(this);
+  }
 }
 
 bool Entity::Move(Direction _direction) {
@@ -87,8 +94,6 @@ bool Entity::IsDeleted() const {
   return deleted;
 }
 
-void Entity::TryDelete()
-{
+void Entity::TryDelete() {
   deleted = (health <= 0);
-  return;
 }

--- a/BattleNetwork/bnExplodeState.h
+++ b/BattleNetwork/bnExplodeState.h
@@ -29,7 +29,7 @@ template<typename Any>
 class ExplodeState : public AIState<Any>
 {
 private:
-  Entity * explosion;
+  Entity* explosion;
   sf::Shader whiteout;
 
 public:

--- a/BattleNetwork/bnLongExplosion.cpp
+++ b/BattleNetwork/bnLongExplosion.cpp
@@ -38,35 +38,34 @@ LongExplosion::LongExplosion(Field* _field, Team _team)
 }
 
 void LongExplosion::Update(float _elapsed) {
-  if (explosionProgress == 0.0f) {
+  if (explosionProgress <= 0.0f) {
     AudioResourceManager::GetInstance().Play(AudioType::EXPLODE);
     x1 = tile->getPosition().x - 10.0f;
     y1 = tile->getPosition().y - 35.f;
   }
-  if (explosionProgress2 == 0.0f) {
+
+  if (explosionProgress2 <= 0.0f) {
     x2 = tile->getPosition().x + 10.0f;
     y2 = tile->getPosition().y - 50.0f;
   }
-  explosionProgress += 0.020f;
+
+  explosionProgress += 0.02f;
   if (explosionProgress >= 0.3f) {
-    explosionProgress2 += 0.020f;
-    if (explosionProgress >= 1.0f) {
-    }
-    if (explosionProgress2 >= 0.8f) {
-      deleted = true;
-      return;
-    }
+    explosionProgress2 += 0.02f;
     explosion2.setScale(2.f, 2.f);
     explosion2.setPosition(x2, y2);
-    explode(explosion2, explosionProgress2);
+    explode(explosion2, fmin(explosionProgress2, 1.0f));
   }
 
   if (explosionProgress <= 1.f) {
     explosion.setScale(2.f, 2.f);
     explosion.setPosition(x1, y1);
-    explode(explosion, explosionProgress);
+    explode(explosion, fmin(explosionProgress, 1.0f));
   }
-  return;
+
+  if (explosionProgress2 >= 0.8f) {
+    deleted = true;
+  }
 }
 
 vector<Drawable*> LongExplosion::GetMiscComponents() {

--- a/BattleNetwork/bnMettaur.cpp
+++ b/BattleNetwork/bnMettaur.cpp
@@ -96,20 +96,19 @@ int* Mettaur::GetAnimOffset() {
 
 void Mettaur::Update(float _elapsed) {
   healthUI->Update();
+  this->StateUpdate(_elapsed);
 
   // Explode if health depleted
   if (GetHealth() <= 0) {
-    this->StateChange(new ExplodeState<Mettaur>());
-    this->StateUpdate(_elapsed);
-    return;
+    this->StateChange(new ExplodeState<Mettaur>()); // TODO: Do not call this every frame, only once would be better
+    this->Lock();
+  } else {
+    this->RefreshTexture();
+    this->SetShader(nullptr);
+    animationComponent.update(_elapsed);
   }
 
-  this->StateUpdate(_elapsed);
-
-  RefreshTexture();
-  SetShader(nullptr);
-  animationComponent.update(_elapsed);
-
+  Entity::Update(_elapsed);
 }
 
 void Mettaur::RefreshTexture() {

--- a/BattleNetwork/bnPlayer.cpp
+++ b/BattleNetwork/bnPlayer.cpp
@@ -76,6 +76,8 @@ void Player::Update(float _elapsed) {
   //Components updates
   chargeComponent.update(_elapsed);
   animationComponent.update(_elapsed);
+
+  Entity::Update(_elapsed);
 }
 
 bool Player::Move(Direction _direction) {

--- a/BattleNetwork/bnProgsMan.cpp
+++ b/BattleNetwork/bnProgsMan.cpp
@@ -226,6 +226,7 @@ void ProgsMan::Update(float _elapsed) {
   RefreshTexture();
   healthUI->Update();
   SetShader(nullptr);
+  Entity::Update(_elapsed);
 }
 
 bool ProgsMan::Move(Direction _direction) {

--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -154,11 +154,8 @@ void Tile::Update(float _elapsed) {
   vector<Entity*> copy = this->entities;
   for (auto entity = copy.begin(); entity < copy.end(); ++entity) {
     (*entity)->Update(_elapsed);
-      if ((*entity)->IsDeleted()) {
-      this->RemoveEntity(*entity);
-      field->RemoveEntity(*entity);
-    }
   }
+
   this->RefreshTexture();
 
   if (state == TileState::BROKEN) {


### PR DESCRIPTION
@TheMaverickProgrammer 
* fmin was added to progress of animations since it would crash if animation isn't between [0, 1]
* Now entity removes itself from field and tile if it sees itself as deleted (must call parent Update function at the end of child's implementation). Reason is that I found it weird that the tile would do this, also I think it was causing a delay for the entity to be finally removed.